### PR TITLE
Modified plugin.json to suppress annoying deprecation warning and file not found warning.

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -7,8 +7,7 @@
 	"hooks": [
 		{ "hook": "filter:post.parse", "method": "parse", "callbacked": true }
 	],
-	"staticDir": "./static",
 	"css": [
-		"style.css"
+		"./static/style.css"
 	]
 }


### PR DESCRIPTION
warn: [plugins/nodebb-plugin-dailymotion] staticDir is deprecated, use staticDirs instead
warn: [meta/css] File not found! nodebb-plugin-dailymotion/style.css
